### PR TITLE
Altera sorting de pré-tabelas para comando Unix

### DIFF
--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -25,7 +25,7 @@ OUTPUT_DIRECTORY = os.environ.get(
 
 def read_processed_log(filepath, delimiter='\t'):
     """
-    Lê um arquivo de log processado e organizada os dados por dia.
+    Lê um arquivo de log processado e organiza os dados por dia.
 
     Parameters
     ----------
@@ -50,13 +50,13 @@ def read_processed_log(filepath, delimiter='\t'):
     with open(filepath) as fin:
         logging.info('Lendo %s' % filepath)
         csv_reader = csv.DictReader(fin, delimiter=delimiter)
-        
+
         for line in csv_reader:
             ymd = line.get('serverTime').split(' ')[0]
-            
+
             if ymd not in data:
                 data[ymd] = []
-            
+
             data[ymd].append(line)
 
     return data
@@ -170,14 +170,14 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '-f', '--file',
+        '-f', '--input_file',
         required=True,
         help='Arquivo de log pré-processado',
     )
 
     parser.add_argument(
         '-o',
-        '--output',
+        '--output_directory',
         default=OUTPUT_DIRECTORY,
         help='Diretório de saída',
     )
@@ -190,6 +190,6 @@ def main():
         datefmt='%d/%b/%Y %H:%M:%S',
     )
 
-    check_dir(params.output)
-    
-    generate_pretables(params.file, params.output)
+    check_dir(params.output_directory)
+
+    generate_pretables(params.input_file, params.output_directory)

--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -91,10 +91,26 @@ def read_pretable(filepath, delimiter='\t', ignore_header=True):
             yield d.strip().split(delimiter)
 
 
-def write_pretable(filepath, header, sort_field, data, delimiter='\t'):
+def _get_formatted_data(data, header, join_char):
+    """Método auxiliar para extrair dados de dicionário.
+
+    Parameters
+    ----------
+    data : dict
+        Dicionário de dados
+    header : list
+        Chaves cujos valores serão usados para extrair os dados
+    join_char: str
+        Caractere utilizado para agrupar itens em uma string
+
+    Yields
+    ------
+    str
+        Uma string delimitada por join_char que representa os valores obtidos de data
     """
-    Grava arquivo de pré-tabela.
-    Caso arquivo já exista, lê dados pré-existentes e gera uma versão ordenada dos dados.
+    for d in data:
+        els = [d.get(h) for h in header]
+        yield join_char.join(els)
 
     Parameters
     ----------

--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -1,6 +1,5 @@
 import argparse
 import csv
-import ipaddress
 import logging
 import os
 
@@ -20,6 +19,11 @@ LOGGING_LEVEL = os.environ.get(
 OUTPUT_DIRECTORY = os.environ.get(
     'OUTPUT_DIRECTORY',
     'data/pretables/'
+)
+
+UNSORTED_POSFIX = os.environ.get(
+    'UNSORTED_POSFIX',
+    'unsorted'
 )
 
 
@@ -147,7 +151,7 @@ def write_pretable(filepath, header, data, delimiter='\t'):
 
 def generate_pretables(filepath, output_directory, extension='tsv', delimiter='\t'):
     """
-    Gera arquivo(s) com os dados de log processados e ordenados.
+    Gera arquivo(s) com os dados de log processados.
     Grava um arquivo por dia.
 
     Parameters
@@ -162,10 +166,21 @@ def generate_pretables(filepath, output_directory, extension='tsv', delimiter='\
         Separador de colunas dos arquivos a serem gerados
     """
     ymd_to_data = read_processed_log(filepath)
-    
-    for y, d in ymd_to_data.items():
-        pretable_filepath = generate_filepath_with_filename(output_directory, y, extension)
-        write_pretable(pretable_filepath, PRETABLE_FILE_HEADER, 'ip', d, delimiter)
+
+    for ymd, d in ymd_to_data.items():
+        pretable_filepath = generate_filepath_with_filename(
+            directory=output_directory,
+            filename=ymd,
+            posfix=UNSORTED_POSFIX,
+            extension=extension,
+        )
+
+        write_pretable(
+            filepath=pretable_filepath,
+            header=PRETABLE_FILE_HEADER,
+            data=d,
+            delimiter=delimiter,
+        )
 
 
 def main():

--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -6,7 +6,6 @@ import os
 
 from app.utils.file import (
     check_dir,
-    create_backup,
     create_file_with_header,
     generate_filepath_with_filename,
 )

--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -112,14 +112,18 @@ def _get_formatted_data(data, header, join_char):
         els = [d.get(h) for h in header]
         yield join_char.join(els)
 
+
+def write_pretable(filepath, header, data, delimiter='\t'):
+    """
+    Grava arquivo de pré-tabela não ordenado.
+    Caso arquivo já exista, acrescenta nele os dados novos.
+
     Parameters
     ----------
     filepath : str
         Nome do arquivo de pré-tabela
     header: list
         Lista de strings que representam o cabeçalho do arquivo de saída
-    sort_field: str
-        Nome do campo de ordenação
     data: dict
         Dicionário contendo valores de acesso
     delimiter: str
@@ -130,32 +134,13 @@ def _get_formatted_data(data, header, join_char):
     str
         Caminho do arquivo de pré-tabela gravado
     """
-    tmp_data = [[i.get(h) for h in header] for i in data]
+    if not os.path.exists(filepath):
+        create_file_with_header(filepath, header)
 
-    if os.path.exists(filepath):
-        # cria cópia de backup de arquivo pré-existente
-        bak_output = create_backup(filepath)
-        logging.info('Gerado backup %s' % bak_output)
+    outfile = open(filepath, 'a')
 
-        # lê dados dados pré-existentes
-        tmp_data += read_pretable(filepath, delimiter)
-
-    # cria arquivo com cabeçalho conteúdo
-    create_file_with_header(filepath, header)
-
-    # remove linhas repetidas
-    lines = set([delimiter.join(i) for i in tmp_data])
-
-    # ordena as linhas de acordo com o IP
-
-    logging.info('Ordenando dados')
-    sorted_lines = sorted([l.split(delimiter) for l in lines], key=lambda x: ipaddress.IPv4Address(x[header.index(sort_field)]))
-
-    logging.info('Gravando dados em %s' % filepath)
-    with open(filepath, 'w') as fout:
-        fout.write(delimiter.join(header) + '\n')
-        for i in sorted_lines:
-            fout.write(delimiter.join(i) + '\n')
+    for fd in _get_formatted_data(data, header, delimiter):
+        outfile.write(fd + '\n')
 
     return filepath
 

--- a/app/proc/generate_pretable.py
+++ b/app/proc/generate_pretable.py
@@ -87,7 +87,8 @@ def read_pretable(filepath, delimiter='\t', ignore_header=True):
     with open(filepath) as fin:
         if ignore_header:
             fin.readline()
-        return [d.strip().split(delimiter) for d in fin]
+        for d in fin:
+            yield d.strip().split(delimiter)
 
 
 def write_pretable(filepath, header, sort_field, data, delimiter='\t'):

--- a/app/utils/file.py
+++ b/app/utils/file.py
@@ -64,13 +64,3 @@ def generate_filepath_with_filename(directory, filename, extension='tsv'):
 def create_file_with_header(path, header=[], delimiter='\t'):
     with open(path, 'w') as fout:
         fout.write(delimiter.join(header) + '\n')
-
-
-def create_backup(path_in):
-    path_out = f'{path_in}.{datetime.datetime.utcnow().timestamp()}.bak.gz'
-
-    with open(path_in, 'rb') as fin:
-        with gzip.open(path_out, 'wb') as fout:
-            shutil.copyfileobj(fin, fout)
-
-    return path_out

--- a/app/utils/file.py
+++ b/app/utils/file.py
@@ -57,7 +57,9 @@ def generate_filepath_with_date(directory, date, extension='tsv'):
     return os.path.join(directory, filename)
 
 
-def generate_filepath_with_filename(directory, filename, extension='tsv'):
+def generate_filepath_with_filename(directory, filename, posfix, extension='tsv'):
+    if posfix:
+        return os.path.join(directory, f'{filename}.{posfix}.{extension}')
     return os.path.join(directory, f'{filename}.{extension}')
 
 

--- a/scripts/sort_uniq.sh
+++ b/scripts/sort_uniq.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+help(){
+	echo "SciELO Usage COUNTER - Sort and dedup script"
+	echo "Please, inform:"
+	echo "   1. The input file (parameter -i)"
+	echo "   2. The output file (parameter -o)"
+	echo ""
+	echo "For example:"
+	echo ""
+	echo "   sort_uniq.sh -i 2018-06-03.unsorted.tsv -o 2018.06.03.tsv"
+	echo ""
+}
+
+run(){
+	UNSORTED_FILE=$1;
+	SORTED_FILE=$2;
+
+    echo "[Processando] $UNSORTED_FILE";
+    echo "[Gravando] $SORTED_FILE";
+    sort -r -t $'\t' -k 4 $UNSORTED_FILE | uniq > $SORTED_FILE;
+}
+
+while getopts i:o: opts; do
+	case ${opts} in
+		# Arquivo de saída (IP ordenado por ordem alfabética e sem linhas duplicadas)
+      	o) SORTED_FILE=${OPTARG} ;;
+
+		# Arquivo de entrada
+		i) UNSORTED_FILE=${OPTARG} ;;
+	esac
+done
+
+if [[ -z "$SORTED_FILE" || -z "$UNSORTED_FILE" ]]
+	then
+		help;
+		exit;
+	else
+		run $UNSORTED_FILE $SORTED_FILE;
+fi


### PR DESCRIPTION
Este PR resolve um problema de consumo de memória ao ordenar os arquivos de pré-tabelas por IP.

Como são arquivos grandes, carregar um dia (dois ou mais arquivos) em memória para ordenar e remover linhas repetidas torna-se custoso em termos de memória (e tem ocorrido estouro de memória para alguns dias de 2018-06.

Este PR resolve esse problema delegando a função de fazer sort e remover linhas repetidas para os comandos `sort` e `uniq` do Unix.

A aplicação ficará responsável apenas por mesclar as linhas nos dias correspondentes (um mesmo arquivo de log pode conter dados do dia atual e dos dias anterior e posterior).